### PR TITLE
Remove Clp_C_Interface.h from source list

### DIFF
--- a/clp_lib_sources.txt
+++ b/clp_lib_sources.txt
@@ -4,7 +4,6 @@ ClpConstraint.cpp
 ClpConstraintLinear.cpp
 ClpConstraintQuadratic.cpp
 Clp_C_Interface.cpp
-Clp_C_Interface.h
 ClpDualRowDantzig.cpp
 ClpDualRowPivot.cpp
 ClpDualRowSteepest.cpp


### PR DESCRIPTION
Clp_C_Interface.h got compiled into a hashed object file. Later (incremental) builds could then recompile the header, but leading to a different hashed object file, thereby producing linker errors.

We don't need the header in the list of sources, everything works without the header file in this list.